### PR TITLE
Using content_scripts

### DIFF
--- a/app/src/main/assets/messaging/custom.js
+++ b/app/src/main/assets/messaging/custom.js
@@ -1,1 +1,6 @@
-function(){var elements = document.getElementsByClassName('infobox');for (var i=0; i<elements.length; i++){elements[i].style.backgroundColor = '#FFCD18';}}
+    var elements = document.getElementsByClassName('infobox');
+     for (var i=0; i<elements.length; i++){
+         elements[i].style.backgroundColor = '#FFCD18';
+    }
+
+browser.runtime.sendNativeMessage("browser", "Color set");

--- a/app/src/main/assets/messaging/manifest.json
+++ b/app/src/main/assets/messaging/manifest.json
@@ -3,9 +3,12 @@
   "name": "messaging",
   "version": "1.0",
   "description": "Example messaging web extension.",
-  "background": {
-    "scripts": ["background.js"]
-  },
+  "content_scripts": [
+    {
+      "matches": ["https://en.m.wikipedia.org/wiki/JavaScript"],
+      "js": ["custom.js"]
+    }
+  ],
   "permissions": [
     "nativeMessaging",
     "geckoViewAddons"


### PR DESCRIPTION
Replaying to your request on https://forums.raywenderlich.com/t/android-tutorial-for-geckoview-getting-started-raywenderlich-com/77654/8

I made some changes to be able to change the color on the background color on the `infobox` classes.

I think the main problem was that you were using `background scripts ` instead of content script. For this reason your script was executed in context different from web page one.


> A content script is a part of your extension that runs in the context of a particular web page (as opposed to background scripts which are part of the extension, or scripts which are part of the web site itself, such as those loaded using the <script> element). 

For more info take a look at the [docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts).